### PR TITLE
Service `GET /recruiter`

### DIFF
--- a/src/service/suggestions.ts
+++ b/src/service/suggestions.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { SuggestionsSchema } from '../schemas/Suggestions';
+
+const API_URL: string = 'http://localhost:8080';
+
+export async function getSuggestionsRecruiter(): Promise<SuggestionsSchema[]> {
+  try {
+    const response = await axios.get<SuggestionsSchema[]>(`${API_URL}/api/v1/suggestions/recruiter`);
+    return response.data;
+  } catch (error) {
+    console.error('Erro ao buscar dados:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
Criei uma função no service para lidar com a requisição GET/ recruiter que torna uma lista de id e nomes do tipo SuggestionsSchema dos recrutadores e não possui parametros

resolve #37 
Chamei a função na page para testes, segue resultados:

![image](https://github.com/user-attachments/assets/8f15f7bd-9c71-4661-8422-4cca5e96c429)

