### PR TITLE
Translations  barChart and DatePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/stack": "^6.4.1",
     "axis": "^1.0.0",
+    "date-fns": "^4.1.0",
     "expo": "~51.0.32",
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       axis:
         specifier: ^1.0.0
         version: 1.0.0
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       expo:
         specifier: ~51.0.32
         version: 51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
@@ -2352,6 +2355,9 @@ packages:
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -8907,6 +8913,8 @@ snapshots:
       is-data-view: 1.0.1
 
   date-fns@3.6.0: {}
+
+  date-fns@4.1.0: {}
 
   dayjs@1.11.13: {}
 

--- a/src/components/barChart.tsx
+++ b/src/components/barChart.tsx
@@ -18,6 +18,24 @@ type BarChartProps = {
   data: DataItem[];
 };
 
+const translateMonth = (month: string) => {
+  const monthTranslations: { [key: string]: string } = {
+    January: 'Janeiro',
+    February: 'Fevereiro',
+    March: 'Março',
+    April: 'Abril',
+    May: 'Maio',
+    June: 'Junho',
+    July: 'Julho',
+    August: 'Agosto',
+    September: 'Setembro',
+    October: 'Outubro',
+    November: 'Novembro',
+    December: 'Dezembro',
+  };
+  return monthTranslations[month] || month;
+};
+
 export default function BarChart({ data }: BarChartProps) {
   const { width } = Dimensions.get('window');
 
@@ -53,6 +71,7 @@ export default function BarChart({ data }: BarChartProps) {
             },
             grid: { stroke: 'none' },
           }}
+          tickFormat={(t) => translateMonth(t)}
         />
 
         <VictoryAxis

--- a/src/components/filter.tsx
+++ b/src/components/filter.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import { View, TextInput, StyleSheet } from 'react-native';
-import DatePicker from 'react-datepicker';
+import DatePicker, { registerLocale } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import {ptBR} from 'date-fns/locale'
+
+registerLocale('pt-BR', ptBR);
 
 type FilterProps = {
   placeholder: string;
@@ -25,8 +28,9 @@ const Filter = ({ placeholder, onChange, type }: FilterProps) => {
           <DatePicker
             selected={date}
             onChange={handleDateChange}
-            dateFormat="yyyy-MM-dd"
+            dateFormat="dd/MM/yyyy"
             placeholderText={placeholder}
+            locale="pt-BR"
             className="react-datepicker-wrapper"
             wrapperClassName="react-datepicker-container"
             popperClassName="react-datepicker-popper"


### PR DESCRIPTION
Translations months in the barChart and DatePicker location in pt-br.
resolve #54 
"Ajustar o valor da taxa de concorrência, deverá ser com duas casas depois da vírgula" - Better a solution in the back-end, because the response in json only contains one decimal place.
